### PR TITLE
Add shared component defaults for HelmRelease configurations

### DIFF
--- a/clusters/dextek/apps/actions-runner-system/actions-runner-controller/app/helmrelease.yaml
+++ b/clusters/dextek/apps/actions-runner-system/actions-runner-controller/app/helmrelease.yaml
@@ -23,14 +23,5 @@ spec:
   chartRef:
     kind: OCIRepository
     name: gha-runner-scale-set-controller
-  install:
-    crds: CreateReplace
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    crds: CreateReplace
-    remediation:
-      retries: 3
   values:
     fullnameOverride: *name

--- a/clusters/dextek/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/clusters/dextek/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -18,6 +18,8 @@ spec:
   wait: true
   interval: 30m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app
@@ -44,6 +46,8 @@ spec:
   wait: true
   interval: 30m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/actions-runner-system/actions-runner-controller/runners/nix-config/helmrelease.yaml
+++ b/clusters/dextek/apps/actions-runner-system/actions-runner-controller/runners/nix-config/helmrelease.yaml
@@ -23,13 +23,6 @@ spec:
   chartRef:
     kind: OCIRepository
     name: gha-runner-scale-set
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     githubConfigUrl: https://github.com/krezh/nix-config
     githubConfigSecret: nix-config-runner-secret

--- a/clusters/dextek/apps/auth/authentik/app/helmrelease.yaml
+++ b/clusters/dextek/apps/auth/authentik/app/helmrelease.yaml
@@ -14,14 +14,6 @@ spec:
         kind: HelmRepository
         name: authentik
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     global:
       podAnnotations:

--- a/clusters/dextek/apps/auth/authentik/ks.yaml
+++ b/clusters/dextek/apps/auth/authentik/ks.yaml
@@ -23,6 +23,8 @@ spec:
   wait: true
   interval: 30m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/auth/teleport/ks.yaml
+++ b/clusters/dextek/apps/auth/teleport/ks.yaml
@@ -18,6 +18,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app
@@ -42,3 +44,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/cert-manager/app/helmrelease.yaml
+++ b/clusters/dextek/apps/cert-manager/app/helmrelease.yaml
@@ -15,13 +15,6 @@ spec:
         kind: HelmRepository
         name: jetstack
         namespace: flux-system
-  maxHistory: 3
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     installCRDs: true
     replicaCount: 1

--- a/clusters/dextek/apps/cert-manager/ks.yaml
+++ b/clusters/dextek/apps/cert-manager/ks.yaml
@@ -15,6 +15,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -33,3 +35,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/cert-manager/ks.yaml
+++ b/clusters/dextek/apps/cert-manager/ks.yaml
@@ -16,7 +16,7 @@ spec:
   retryInterval: 1m
   timeout: 3m
   components:
-    - ../../../../../shared/components/defaults
+    - ../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -36,4 +36,4 @@ spec:
   retryInterval: 1m
   timeout: 3m
   components:
-    - ../../../../../shared/components/defaults
+    - ../../../../shared/components/defaults

--- a/clusters/dextek/apps/databases/crunchy-postgres/app/helmrelease.yaml
+++ b/clusters/dextek/apps/databases/crunchy-postgres/app/helmrelease.yaml
@@ -15,18 +15,6 @@ spec:
         kind: HelmRepository
         name: crunchydata
         namespace: flux-system
-  maxHistory: 2
-  install:
-    crds: CreateReplace
-    remediation:
-      retries: 3
-  upgrade:
-    crds: CreateReplace
-    cleanupOnFail: true
-    remediation:
-      retries: 3
-  uninstall:
-    keepHistory: false
   values:
     monitoring: true
     install:

--- a/clusters/dextek/apps/databases/crunchy-postgres/ks.yaml
+++ b/clusters/dextek/apps/databases/crunchy-postgres/ks.yaml
@@ -18,6 +18,8 @@ spec:
   wait: true
   interval: 30m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -42,6 +44,8 @@ spec:
   wait: true
   interval: 30m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -64,6 +68,8 @@ spec:
   wait: true
   interval: 30m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -86,3 +92,5 @@ spec:
   wait: true
   interval: 30m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/databases/crunchy-postgres/userinit-controller/helmrelease.yaml
+++ b/clusters/dextek/apps/databases/crunchy-postgres/userinit-controller/helmrelease.yaml
@@ -14,17 +14,5 @@ spec:
         kind: HelmRepository
         name: crunchy-userinit
         namespace: flux-system
-  maxHistory: 2
-  install:
-    crds: CreateReplace
-    remediation:
-      retries: 3
-  upgrade:
-    crds: CreateReplace
-    cleanupOnFail: true
-    remediation:
-      retries: 3
-  uninstall:
-    keepHistory: false
   values:
     fullnameOverride: crunchy-userinit-controller

--- a/clusters/dextek/apps/databases/dragonfly/app/helmrelease.yaml
+++ b/clusters/dextek/apps/databases/dragonfly/app/helmrelease.yaml
@@ -14,14 +14,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     controllers:
       dragonfly-operator:

--- a/clusters/dextek/apps/databases/dragonfly/ks.yaml
+++ b/clusters/dextek/apps/databases/dragonfly/ks.yaml
@@ -21,6 +21,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -44,3 +46,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/databases/pgweb/app/helmrelease.yaml
+++ b/clusters/dextek/apps/databases/pgweb/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/databases/pgweb/ks.yaml
+++ b/clusters/dextek/apps/databases/pgweb/ks.yaml
@@ -23,6 +23,7 @@ spec:
     name: flux-system
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/databases/valkey/app/helmrelease.yaml
+++ b/clusters/dextek/apps/databases/valkey/app/helmrelease.yaml
@@ -15,17 +15,6 @@ spec:
         kind: HelmRepository
         name: groundhog2k
         namespace: flux-system
-  maxHistory: 3
-  install:
-    createNamespace: true
-    remediation:
-      retries: 3
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
-  uninstall:
-    keepHistory: false
   values:
     image:
       registry: ghcr.io

--- a/clusters/dextek/apps/databases/valkey/ks.yaml
+++ b/clusters/dextek/apps/databases/valkey/ks.yaml
@@ -17,3 +17,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/default/attic/app/helmrelease.yaml
+++ b/clusters/dextek/apps/default/attic/app/helmrelease.yaml
@@ -15,16 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  maxHistory: 2
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
-  uninstall:
-    keepHistory: false
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/default/attic/ks.yaml
+++ b/clusters/dextek/apps/default/attic/ks.yaml
@@ -23,6 +23,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 15m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/default/atuin/app/helmrelease.yaml
+++ b/clusters/dextek/apps/default/atuin/app/helmrelease.yaml
@@ -15,16 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  maxHistory: 2
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
-  uninstall:
-    keepHistory: false
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/default/atuin/ks.yaml
+++ b/clusters/dextek/apps/default/atuin/ks.yaml
@@ -18,3 +18,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/default/changedetection/app/helmrelease.yaml
+++ b/clusters/dextek/apps/default/changedetection/app/helmrelease.yaml
@@ -15,17 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  maxHistory: 3
-  install:
-    createNamespace: true
-    remediation:
-      retries: 3
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
-  uninstall:
-    keepHistory: false
   values:
     controllers:
       main:

--- a/clusters/dextek/apps/default/changedetection/ks.yaml
+++ b/clusters/dextek/apps/default/changedetection/ks.yaml
@@ -23,6 +23,7 @@ spec:
   timeout: 3m
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/default/cyberchef/app/helmrelease.yaml
+++ b/clusters/dextek/apps/default/cyberchef/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/default/cyberchef/ks.yaml
+++ b/clusters/dextek/apps/default/cyberchef/ks.yaml
@@ -19,3 +19,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/default/echo-server/app/helmrelease.yaml
+++ b/clusters/dextek/apps/default/echo-server/app/helmrelease.yaml
@@ -15,13 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   uninstall:
     keepHistory: false
   values:

--- a/clusters/dextek/apps/default/echo-server/ks.yaml
+++ b/clusters/dextek/apps/default/echo-server/ks.yaml
@@ -19,3 +19,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/default/home-assistant/app/helmrelease.yaml
+++ b/clusters/dextek/apps/default/home-assistant/app/helmrelease.yaml
@@ -16,13 +16,6 @@ spec:
         name: bjw-s
         namespace: flux-system
   maxHistory: 3
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   uninstall:
     keepHistory: false
   values:

--- a/clusters/dextek/apps/default/home-assistant/ks.yaml
+++ b/clusters/dextek/apps/default/home-assistant/ks.yaml
@@ -23,6 +23,7 @@ spec:
   timeout: 3m
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/default/homepage/krezh/helmrelease.yaml
+++ b/clusters/dextek/apps/default/homepage/krezh/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 5
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/default/homepage/ks.yaml
+++ b/clusters/dextek/apps/default/homepage/ks.yaml
@@ -21,6 +21,7 @@ spec:
   timeout: 3m
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app
@@ -49,6 +50,7 @@ spec:
   timeout: 3m
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/default/homepage/users/helmrelease.yaml
+++ b/clusters/dextek/apps/default/homepage/users/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 5
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/default/it-tools/app/helmrelease.yaml
+++ b/clusters/dextek/apps/default/it-tools/app/helmrelease.yaml
@@ -14,14 +14,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     controllers:
       it-tools:

--- a/clusters/dextek/apps/default/it-tools/ks.yaml
+++ b/clusters/dextek/apps/default/it-tools/ks.yaml
@@ -19,3 +19,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/default/jellyfin/app/helmrelease.yaml
+++ b/clusters/dextek/apps/default/jellyfin/app/helmrelease.yaml
@@ -15,13 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     controllers:
       jellyfin:

--- a/clusters/dextek/apps/default/jellyfin/ks.yaml
+++ b/clusters/dextek/apps/default/jellyfin/ks.yaml
@@ -21,6 +21,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 15m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app
@@ -50,3 +52,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 15m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/default/jellyfin/tools/sync/helmrelease.yaml
+++ b/clusters/dextek/apps/default/jellyfin/tools/sync/helmrelease.yaml
@@ -14,13 +14,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     controllers:
       jellyfin-sync:

--- a/clusters/dextek/apps/default/karakeep/app/helmrelease.yaml
+++ b/clusters/dextek/apps/default/karakeep/app/helmrelease.yaml
@@ -15,13 +15,6 @@ spec:
         name: bjw-s
         namespace: flux-system
   maxHistory: 3
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   uninstall:
     keepHistory: false
   values:

--- a/clusters/dextek/apps/default/karakeep/ks.yaml
+++ b/clusters/dextek/apps/default/karakeep/ks.yaml
@@ -21,6 +21,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 15m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/default/mealie/ks.yaml
+++ b/clusters/dextek/apps/default/mealie/ks.yaml
@@ -21,6 +21,8 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/default/n8n/ks.yaml
+++ b/clusters/dextek/apps/default/n8n/ks.yaml
@@ -21,6 +21,7 @@ spec:
   timeout: 3m
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/default/ntfy/app/helmrelease.yaml
+++ b/clusters/dextek/apps/default/ntfy/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/default/ntfy/ks.yaml
+++ b/clusters/dextek/apps/default/ntfy/ks.yaml
@@ -21,6 +21,8 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/default/ollama/app/helmrelease.yaml
+++ b/clusters/dextek/apps/default/ollama/app/helmrelease.yaml
@@ -13,16 +13,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  maxHistory: 2
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
-  uninstall:
-    keepHistory: false
   values:
     controllers:
       *app :

--- a/clusters/dextek/apps/default/ollama/ks.yaml
+++ b/clusters/dextek/apps/default/ollama/ks.yaml
@@ -21,6 +21,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app
@@ -51,6 +53,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/default/ollama/open-webui/helmrelease.yaml
+++ b/clusters/dextek/apps/default/ollama/open-webui/helmrelease.yaml
@@ -13,16 +13,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  maxHistory: 2
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
-  uninstall:
-    keepHistory: false
   values:
     controllers:
       app:

--- a/clusters/dextek/apps/default/plex/app/helmrelease.yaml
+++ b/clusters/dextek/apps/default/plex/app/helmrelease.yaml
@@ -16,13 +16,6 @@ spec:
         name: bjw-s
         namespace: flux-system
   maxHistory: 3
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   uninstall:
     keepHistory: false
   values:

--- a/clusters/dextek/apps/default/plex/ks.yaml
+++ b/clusters/dextek/apps/default/plex/ks.yaml
@@ -21,6 +21,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 15m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app
@@ -49,6 +51,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 15m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/default/plex/plex-auto-languages/helmrelease.yaml
+++ b/clusters/dextek/apps/default/plex/plex-auto-languages/helmrelease.yaml
@@ -14,14 +14,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     controllers:
       plex-auto-languages:

--- a/clusters/dextek/apps/default/publish-k8s-schemas/ks.yaml
+++ b/clusters/dextek/apps/default/publish-k8s-schemas/ks.yaml
@@ -21,3 +21,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/default/redbot/app/helmrelease.yaml
+++ b/clusters/dextek/apps/default/redbot/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     controllers:
       app:

--- a/clusters/dextek/apps/default/redbot/ks.yaml
+++ b/clusters/dextek/apps/default/redbot/ks.yaml
@@ -21,6 +21,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/default/tautulli/app/helmrelease.yaml
+++ b/clusters/dextek/apps/default/tautulli/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/default/tautulli/ks.yaml
+++ b/clusters/dextek/apps/default/tautulli/ks.yaml
@@ -21,6 +21,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/default/unifi-controller/ks.yaml
+++ b/clusters/dextek/apps/default/unifi-controller/ks.yaml
@@ -21,6 +21,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/default/wallos/app/helmrelease.yaml
+++ b/clusters/dextek/apps/default/wallos/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     controllers:
       wallos:

--- a/clusters/dextek/apps/default/wallos/ks.yaml
+++ b/clusters/dextek/apps/default/wallos/ks.yaml
@@ -21,6 +21,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/default/zipline/ks.yaml
+++ b/clusters/dextek/apps/default/zipline/ks.yaml
@@ -21,6 +21,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/downloads/bazarr/app/helmrelease.yaml
+++ b/clusters/dextek/apps/downloads/bazarr/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/downloads/bazarr/ks.yaml
+++ b/clusters/dextek/apps/downloads/bazarr/ks.yaml
@@ -23,6 +23,7 @@ spec:
     name: flux-system
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/downloads/checkrr/app/helmrelease.yaml
+++ b/clusters/dextek/apps/downloads/checkrr/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/downloads/checkrr/ks.yaml
+++ b/clusters/dextek/apps/downloads/checkrr/ks.yaml
@@ -25,6 +25,7 @@ spec:
     name: flux-system
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/downloads/doplarr/app/helmrelease.yaml
+++ b/clusters/dextek/apps/downloads/doplarr/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/downloads/doplarr/ks.yaml
+++ b/clusters/dextek/apps/downloads/doplarr/ks.yaml
@@ -21,3 +21,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/downloads/flaresolverr/app/helmrelease.yaml
+++ b/clusters/dextek/apps/downloads/flaresolverr/app/helmrelease.yaml
@@ -15,14 +15,6 @@ spec:
         name: bjw-s
         namespace: flux-system
   maxHistory: 2
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   uninstall:
     keepHistory: false
   values:

--- a/clusters/dextek/apps/downloads/flaresolverr/ks.yaml
+++ b/clusters/dextek/apps/downloads/flaresolverr/ks.yaml
@@ -19,3 +19,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/downloads/jdownloader/app/helmrelease.yaml
+++ b/clusters/dextek/apps/downloads/jdownloader/app/helmrelease.yaml
@@ -14,16 +14,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  maxHistory: 2
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
-  uninstall:
-    keepHistory: false
   values:
     controllers:
       app:

--- a/clusters/dextek/apps/downloads/jdownloader/ks.yaml
+++ b/clusters/dextek/apps/downloads/jdownloader/ks.yaml
@@ -23,6 +23,7 @@ spec:
   timeout: 3m
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/downloads/jellyseerr-jf/app/helmrelease.yaml
+++ b/clusters/dextek/apps/downloads/jellyseerr-jf/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/downloads/jellyseerr-jf/ks.yaml
+++ b/clusters/dextek/apps/downloads/jellyseerr-jf/ks.yaml
@@ -21,6 +21,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/downloads/jellyseerr/app/helmrelease.yaml
+++ b/clusters/dextek/apps/downloads/jellyseerr/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/downloads/jellyseerr/ks.yaml
+++ b/clusters/dextek/apps/downloads/jellyseerr/ks.yaml
@@ -21,6 +21,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/downloads/maintainerr/app/helmrelease.yaml
+++ b/clusters/dextek/apps/downloads/maintainerr/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     controllers:
       app:

--- a/clusters/dextek/apps/downloads/maintainerr/ks.yaml
+++ b/clusters/dextek/apps/downloads/maintainerr/ks.yaml
@@ -27,6 +27,7 @@ spec:
     name: flux-system
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/downloads/nzbget/ks.yaml
+++ b/clusters/dextek/apps/downloads/nzbget/ks.yaml
@@ -23,6 +23,7 @@ spec:
     name: flux-system
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/downloads/pinchflat/app/helmrelease.yaml
+++ b/clusters/dextek/apps/downloads/pinchflat/app/helmrelease.yaml
@@ -14,14 +14,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     controllers:
       pinchflat:

--- a/clusters/dextek/apps/downloads/pinchflat/ks.yaml
+++ b/clusters/dextek/apps/downloads/pinchflat/ks.yaml
@@ -22,6 +22,7 @@ spec:
   timeout: 5m
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/clusters/dextek/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/downloads/prowlarr/ks.yaml
+++ b/clusters/dextek/apps/downloads/prowlarr/ks.yaml
@@ -24,6 +24,7 @@ spec:
     name: flux-system
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/downloads/qbittorrent/ks.yaml
+++ b/clusters/dextek/apps/downloads/qbittorrent/ks.yaml
@@ -21,6 +21,8 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/downloads/radarr/app/helmrelease.yaml
+++ b/clusters/dextek/apps/downloads/radarr/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/downloads/radarr/ks.yaml
+++ b/clusters/dextek/apps/downloads/radarr/ks.yaml
@@ -23,6 +23,7 @@ spec:
     name: flux-system
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/downloads/recyclarr/app/helmrelease.yaml
+++ b/clusters/dextek/apps/downloads/recyclarr/app/helmrelease.yaml
@@ -15,16 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  maxHistory: 2
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
-  uninstall:
-    keepHistory: false
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/downloads/recyclarr/ks.yaml
+++ b/clusters/dextek/apps/downloads/recyclarr/ks.yaml
@@ -24,6 +24,8 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/downloads/sabnzbd/ks.yaml
+++ b/clusters/dextek/apps/downloads/sabnzbd/ks.yaml
@@ -23,6 +23,7 @@ spec:
     name: flux-system
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/downloads/scraparr/ks.yaml
+++ b/clusters/dextek/apps/downloads/scraparr/ks.yaml
@@ -21,3 +21,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/downloads/sonarr/app/helmrelease.yaml
+++ b/clusters/dextek/apps/downloads/sonarr/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/downloads/sonarr/ks.yaml
+++ b/clusters/dextek/apps/downloads/sonarr/ks.yaml
@@ -23,6 +23,7 @@ spec:
     name: flux-system
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/downloads/whisparr/app/helmrelease.yaml
+++ b/clusters/dextek/apps/downloads/whisparr/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/downloads/whisparr/ks.yaml
+++ b/clusters/dextek/apps/downloads/whisparr/ks.yaml
@@ -23,6 +23,7 @@ spec:
     name: flux-system
   components:
     - ../../../../../shared/components/ext-auth
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/flux-system/flux-operator/app/helmrelease.yaml
+++ b/clusters/dextek/apps/flux-system/flux-operator/app/helmrelease.yaml
@@ -14,14 +14,6 @@ spec:
         kind: HelmRepository
         name: controlplaneio
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   valuesFrom:
     - kind: ConfigMap
       name: flux-operator-helm-values

--- a/clusters/dextek/apps/flux-system/flux-operator/instance/helmrelease.yaml
+++ b/clusters/dextek/apps/flux-system/flux-operator/instance/helmrelease.yaml
@@ -14,14 +14,6 @@ spec:
         kind: HelmRepository
         name: controlplaneio
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   valuesFrom:
     - kind: ConfigMap
       name: flux-instance-helm-values

--- a/clusters/dextek/apps/flux-system/flux-operator/ks.yaml
+++ b/clusters/dextek/apps/flux-system/flux-operator/ks.yaml
@@ -18,6 +18,8 @@ spec:
   wait: false
   interval: 30m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.plexuz.xyz/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -40,3 +42,5 @@ spec:
   wait: false
   interval: 30m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/flux-system/tf-controller/app/helmrelease.yaml
+++ b/clusters/dextek/apps/flux-system/tf-controller/app/helmrelease.yaml
@@ -16,13 +16,6 @@ spec:
         name: tofu-controller
         namespace: flux-system
   maxHistory: 3
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   uninstall:
     keepHistory: false
   values:

--- a/clusters/dextek/apps/flux-system/tf-controller/ks.yaml
+++ b/clusters/dextek/apps/flux-system/tf-controller/ks.yaml
@@ -18,6 +18,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -36,3 +38,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/games/enshrouded/app/helmrelease.yaml
+++ b/clusters/dextek/apps/games/enshrouded/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/games/enshrouded/ks.yaml
+++ b/clusters/dextek/apps/games/enshrouded/ks.yaml
@@ -21,6 +21,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/games/palworld/app/helmrelease.yaml
+++ b/clusters/dextek/apps/games/palworld/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     controllers:
       app:

--- a/clusters/dextek/apps/games/palworld/ks.yaml
+++ b/clusters/dextek/apps/games/palworld/ks.yaml
@@ -21,6 +21,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/games/satisfactory/helmrelease.yaml
+++ b/clusters/dextek/apps/games/satisfactory/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/games/valheim/app/helmrelease.yaml
+++ b/clusters/dextek/apps/games/valheim/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     controllers:
       app:

--- a/clusters/dextek/apps/games/valheim/ks.yaml
+++ b/clusters/dextek/apps/games/valheim/ks.yaml
@@ -21,6 +21,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/games/vrising/app/helmrelease.yaml
+++ b/clusters/dextek/apps/games/vrising/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     controllers:
       app:

--- a/clusters/dextek/apps/games/vrising/ks.yaml
+++ b/clusters/dextek/apps/games/vrising/ks.yaml
@@ -21,6 +21,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/immich/app/helmrelease.yaml
+++ b/clusters/dextek/apps/immich/app/helmrelease.yaml
@@ -15,16 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  maxHistory: 2
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
-  uninstall:
-    keepHistory: false
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/dextek/apps/immich/ks.yaml
+++ b/clusters/dextek/apps/immich/ks.yaml
@@ -19,4 +19,4 @@ spec:
   retryInterval: 1m
   timeout: 5m
   components:
-    - ../../../../../shared/components/defaults
+    - ../../../../shared/components/defaults

--- a/clusters/dextek/apps/immich/ks.yaml
+++ b/clusters/dextek/apps/immich/ks.yaml
@@ -18,3 +18,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/clusters/dextek/apps/kube-system/cilium/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: cilium
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   valuesFrom:
     - kind: ConfigMap
       name: cilium-helm-values

--- a/clusters/dextek/apps/kube-system/cilium/ks.yaml
+++ b/clusters/dextek/apps/kube-system/cilium/ks.yaml
@@ -19,6 +19,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -42,3 +44,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/clusters/dextek/apps/kube-system/coredns/app/helmrelease.yaml
@@ -14,14 +14,6 @@ spec:
         kind: HelmRepository
         name: coredns
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   valuesFrom:
     - kind: ConfigMap
       name: coredns-helm-values

--- a/clusters/dextek/apps/kube-system/coredns/ks.yaml
+++ b/clusters/dextek/apps/kube-system/coredns/ks.yaml
@@ -18,3 +18,5 @@ spec:
   wait: false
   interval: 30m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/kube-system/descheduler/app/helmrelease.yaml
+++ b/clusters/dextek/apps/kube-system/descheduler/app/helmrelease.yaml
@@ -14,14 +14,6 @@ spec:
         kind: HelmRepository
         name: descheduler
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     replicas: 2
     kind: Deployment

--- a/clusters/dextek/apps/kube-system/descheduler/ks.yaml
+++ b/clusters/dextek/apps/kube-system/descheduler/ks.yaml
@@ -15,3 +15,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/kube-system/external-secrets/app/helmrelease.yaml
+++ b/clusters/dextek/apps/kube-system/external-secrets/app/helmrelease.yaml
@@ -16,13 +16,6 @@ spec:
         name: external-secrets
         namespace: flux-system
   maxHistory: 3
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   uninstall:
     keepHistory: false
   values:

--- a/clusters/dextek/apps/kube-system/external-secrets/ks.yaml
+++ b/clusters/dextek/apps/kube-system/external-secrets/ks.yaml
@@ -15,6 +15,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -34,3 +36,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/kube-system/intel-device-plugin/app/helmrelease.yaml
+++ b/clusters/dextek/apps/kube-system/intel-device-plugin/app/helmrelease.yaml
@@ -13,13 +13,3 @@ spec:
         kind: HelmRepository
         name: intel
         namespace: flux-system
-  install:
-    crds: CreateReplace
-    remediation:
-      retries: 3
-  upgrade:
-    cleanupOnFail: true
-    crds: CreateReplace
-    remediation:
-      strategy: rollback
-      retries: 3

--- a/clusters/dextek/apps/kube-system/intel-device-plugin/gpu/helmrelease.yaml
+++ b/clusters/dextek/apps/kube-system/intel-device-plugin/gpu/helmrelease.yaml
@@ -13,14 +13,6 @@ spec:
         kind: HelmRepository
         name: intel
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     name: intel-gpu-plugin
     sharedDevNum: 99

--- a/clusters/dextek/apps/kube-system/intel-device-plugin/ks.yaml
+++ b/clusters/dextek/apps/kube-system/intel-device-plugin/ks.yaml
@@ -19,6 +19,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -43,3 +45,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/kube-system/irqbalance/app/helmrelease.yaml
+++ b/clusters/dextek/apps/kube-system/irqbalance/app/helmrelease.yaml
@@ -13,14 +13,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     controllers:
       irqbalance:

--- a/clusters/dextek/apps/kube-system/irqbalance/ks.yaml
+++ b/clusters/dextek/apps/kube-system/irqbalance/ks.yaml
@@ -18,3 +18,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/kube-system/k8tz/ks.yaml
+++ b/clusters/dextek/apps/kube-system/k8tz/ks.yaml
@@ -17,3 +17,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/kube-system/kubelet-csr-approver/ks.yaml
+++ b/clusters/dextek/apps/kube-system/kubelet-csr-approver/ks.yaml
@@ -19,3 +19,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/kube-system/metrics-server/app/helmrelease.yaml
+++ b/clusters/dextek/apps/kube-system/metrics-server/app/helmrelease.yaml
@@ -15,14 +15,6 @@ spec:
         kind: HelmRepository
         name: metrics-server
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     metrics:
       enabled: true

--- a/clusters/dextek/apps/kube-system/metrics-server/ks.yaml
+++ b/clusters/dextek/apps/kube-system/metrics-server/ks.yaml
@@ -15,3 +15,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/kube-system/multus/ks.yaml
+++ b/clusters/dextek/apps/kube-system/multus/ks.yaml
@@ -16,6 +16,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -36,3 +38,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/kube-system/node-feature-discovery/ks.yaml
+++ b/clusters/dextek/apps/kube-system/node-feature-discovery/ks.yaml
@@ -15,6 +15,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -34,3 +36,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/kube-system/reloader/app/helmrelease.yaml
+++ b/clusters/dextek/apps/kube-system/reloader/app/helmrelease.yaml
@@ -15,14 +15,6 @@ spec:
         kind: HelmRepository
         name: reloader
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     fullnameOverride: *app
     reloader:

--- a/clusters/dextek/apps/kube-system/reloader/ks.yaml
+++ b/clusters/dextek/apps/kube-system/reloader/ks.yaml
@@ -15,3 +15,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/kube-system/snapshot-controller/ks.yaml
+++ b/clusters/dextek/apps/kube-system/snapshot-controller/ks.yaml
@@ -17,3 +17,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/kube-system/spegel/app/helmrelease.yaml
+++ b/clusters/dextek/apps/kube-system/spegel/app/helmrelease.yaml
@@ -14,13 +14,6 @@ spec:
         kind: HelmRepository
         name: spegel
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   uninstall:
     keepHistory: false
   valuesFrom:

--- a/clusters/dextek/apps/kube-system/spegel/ks.yaml
+++ b/clusters/dextek/apps/kube-system/spegel/ks.yaml
@@ -16,3 +16,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/kube-system/system-upgrade/app/helmrelease.yaml
+++ b/clusters/dextek/apps/kube-system/system-upgrade/app/helmrelease.yaml
@@ -14,14 +14,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     controllers:
       system-upgrade:

--- a/clusters/dextek/apps/kube-system/system-upgrade/ks.yaml
+++ b/clusters/dextek/apps/kube-system/system-upgrade/ks.yaml
@@ -21,6 +21,8 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
@@ -48,6 +50,8 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       # renovate: datasource=github-releases depName=siderolabs/talos

--- a/clusters/dextek/apps/kyverno/kyverno/app/helmrelease.yaml
+++ b/clusters/dextek/apps/kyverno/kyverno/app/helmrelease.yaml
@@ -14,14 +14,6 @@ spec:
         kind: HelmRepository
         name: kyverno
         namespace: flux-system
-  install:
-    remediation:
-      retries: 3
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     crds:
       install: true

--- a/clusters/dextek/apps/kyverno/kyverno/ks.yaml
+++ b/clusters/dextek/apps/kyverno/kyverno/ks.yaml
@@ -18,6 +18,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -40,3 +42,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/monitoring/alloy/app/helmrelease.yaml
+++ b/clusters/dextek/apps/monitoring/alloy/app/helmrelease.yaml
@@ -14,13 +14,6 @@ spec:
         kind: HelmRepository
         name: grafana
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   # https://github.com/grafana/alloy/blob/main/operations/helm/charts/alloy/values.yaml
   values:
     fullnameOverride: alloy

--- a/clusters/dextek/apps/monitoring/alloy/ks.yaml
+++ b/clusters/dextek/apps/monitoring/alloy/ks.yaml
@@ -18,3 +18,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/monitoring/blackbox-exporter/app/helmrelease.yaml
+++ b/clusters/dextek/apps/monitoring/blackbox-exporter/app/helmrelease.yaml
@@ -15,14 +15,6 @@ spec:
         kind: HelmRepository
         name: prometheus-community
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     fullnameOverride: blackbox-exporter
     securityContext:

--- a/clusters/dextek/apps/monitoring/blackbox-exporter/ks.yaml
+++ b/clusters/dextek/apps/monitoring/blackbox-exporter/ks.yaml
@@ -15,3 +15,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/clusters/dextek/apps/monitoring/grafana/app/helmrelease.yaml
@@ -15,10 +15,6 @@ spec:
         name: grafana
         namespace: flux-system
       version: 10.0.0
-  install:
-    crds: Create
-  upgrade:
-    crds: CreateReplace
   # https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
   values:
     env:

--- a/clusters/dextek/apps/monitoring/grafana/ks.yaml
+++ b/clusters/dextek/apps/monitoring/grafana/ks.yaml
@@ -18,3 +18,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/monitoring/graphite-exporter/app/helmrelease.yaml
+++ b/clusters/dextek/apps/monitoring/graphite-exporter/app/helmrelease.yaml
@@ -16,13 +16,6 @@ spec:
         name: bjw-s
         namespace: flux-system
   maxHistory: 3
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   uninstall:
     keepHistory: false
   values:

--- a/clusters/dextek/apps/monitoring/graphite-exporter/ks.yaml
+++ b/clusters/dextek/apps/monitoring/graphite-exporter/ks.yaml
@@ -17,3 +17,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/monitoring/headlamp/app/helmrelease.yaml
+++ b/clusters/dextek/apps/monitoring/headlamp/app/helmrelease.yaml
@@ -17,14 +17,6 @@ spec:
         namespace: flux-system
   driftDetection:
     mode: enabled
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     fullnameOverride: headlamp
     initContainers:

--- a/clusters/dextek/apps/monitoring/headlamp/ks.yaml
+++ b/clusters/dextek/apps/monitoring/headlamp/ks.yaml
@@ -18,3 +18,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/monitoring/kromgo/app/helmrelease.yaml
+++ b/clusters/dextek/apps/monitoring/kromgo/app/helmrelease.yaml
@@ -14,14 +14,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     controllers:
       kromgo:

--- a/clusters/dextek/apps/monitoring/kromgo/ks.yaml
+++ b/clusters/dextek/apps/monitoring/kromgo/ks.yaml
@@ -16,6 +16,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults
   postBuild:
     substitute:
       APP: *app

--- a/clusters/dextek/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/clusters/dextek/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -15,14 +15,6 @@ spec:
         kind: HelmRepository
         name: prometheus-community
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     crds:
       enabled: true

--- a/clusters/dextek/apps/monitoring/kube-prometheus-stack/ks.yaml
+++ b/clusters/dextek/apps/monitoring/kube-prometheus-stack/ks.yaml
@@ -16,3 +16,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/monitoring/loki/app/helmrelease.yaml
+++ b/clusters/dextek/apps/monitoring/loki/app/helmrelease.yaml
@@ -15,16 +15,6 @@ spec:
         kind: HelmRepository
         name: grafana
         namespace: flux-system
-  install:
-    crds: CreateReplace
-    remediation:
-      retries: 3
-  upgrade:
-    cleanupOnFail: true
-    crds: CreateReplace
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     deploymentMode: SingleBinary
     loki:

--- a/clusters/dextek/apps/monitoring/loki/ks.yaml
+++ b/clusters/dextek/apps/monitoring/loki/ks.yaml
@@ -15,3 +15,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/monitoring/mikrotik-exporter/app/helmrelease.yaml
+++ b/clusters/dextek/apps/monitoring/mikrotik-exporter/app/helmrelease.yaml
@@ -16,13 +16,6 @@ spec:
         name: bjw-s
         namespace: flux-system
   maxHistory: 3
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   uninstall:
     keepHistory: false
   values:

--- a/clusters/dextek/apps/monitoring/mikrotik-exporter/ks.yaml
+++ b/clusters/dextek/apps/monitoring/mikrotik-exporter/ks.yaml
@@ -15,3 +15,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/monitoring/nut-exporter/app/helmrelease.yaml
+++ b/clusters/dextek/apps/monitoring/nut-exporter/app/helmrelease.yaml
@@ -15,17 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  maxHistory: 3
-  install:
-    createNamespace: true
-    remediation:
-      retries: 3
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
-  uninstall:
-    keepHistory: false
   values:
     controllers:
       app:

--- a/clusters/dextek/apps/monitoring/nut-exporter/ks.yaml
+++ b/clusters/dextek/apps/monitoring/nut-exporter/ks.yaml
@@ -15,3 +15,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/monitoring/opnsense-exporter/app/helmrelease.yaml
+++ b/clusters/dextek/apps/monitoring/opnsense-exporter/app/helmrelease.yaml
@@ -16,13 +16,6 @@ spec:
         name: bjw-s
         namespace: flux-system
   maxHistory: 3
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   uninstall:
     keepHistory: false
   values:

--- a/clusters/dextek/apps/monitoring/opnsense-exporter/ks.yaml
+++ b/clusters/dextek/apps/monitoring/opnsense-exporter/ks.yaml
@@ -15,3 +15,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/monitoring/silence-operator/app/helmrelease.yaml
+++ b/clusters/dextek/apps/monitoring/silence-operator/app/helmrelease.yaml
@@ -16,13 +16,6 @@ spec:
         namespace: flux-system
   driftDetection:
     mode: enabled
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     alertmanagerAddress: http://kube-prometheus-stack-alertmanager:9093
     image:

--- a/clusters/dextek/apps/monitoring/silence-operator/ks.yaml
+++ b/clusters/dextek/apps/monitoring/silence-operator/ks.yaml
@@ -19,6 +19,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -42,3 +44,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/monitoring/smartctl-exporter/app/helmrelease.yaml
+++ b/clusters/dextek/apps/monitoring/smartctl-exporter/app/helmrelease.yaml
@@ -16,13 +16,6 @@ spec:
         name: prometheus-community
         namespace: flux-system
   maxHistory: 3
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   uninstall:
     keepHistory: false
   values:

--- a/clusters/dextek/apps/monitoring/smartctl-exporter/ks.yaml
+++ b/clusters/dextek/apps/monitoring/smartctl-exporter/ks.yaml
@@ -15,3 +15,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/monitoring/unpoller/app/helmrelease.yaml
+++ b/clusters/dextek/apps/monitoring/unpoller/app/helmrelease.yaml
@@ -16,13 +16,6 @@ spec:
         name: bjw-s
         namespace: flux-system
   maxHistory: 3
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   uninstall:
     keepHistory: false
   values:

--- a/clusters/dextek/apps/monitoring/unpoller/ks.yaml
+++ b/clusters/dextek/apps/monitoring/unpoller/ks.yaml
@@ -15,3 +15,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/network/envoy-gateway/app/helmrelease.yaml
+++ b/clusters/dextek/apps/network/envoy-gateway/app/helmrelease.yaml
@@ -15,15 +15,6 @@ spec:
         kind: HelmRepository
         name: envoy-proxy
         namespace: flux-system
-  install:
-    crds: CreateReplace
-    remediation:
-      retries: -1
-  upgrade:
-    crds: CreateReplace
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     deployment:
       replicas: 3

--- a/clusters/dextek/apps/network/envoy-gateway/ks.yaml
+++ b/clusters/dextek/apps/network/envoy-gateway/ks.yaml
@@ -19,6 +19,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -42,3 +44,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/network/external-dns/app/helmrelease.yaml
+++ b/clusters/dextek/apps/network/external-dns/app/helmrelease.yaml
@@ -15,16 +15,6 @@ spec:
         kind: HelmRepository
         name: external-dns
         namespace: flux-system
-  install:
-    disableSchemaValidation: true # Ref: https://github.com/kubernetes-sigs/external-dns/issues/5206
-    remediation:
-      retries: 3
-  upgrade:
-    cleanupOnFail: true
-    disableSchemaValidation: true # Ref: https://github.com/kubernetes-sigs/external-dns/issues/5206
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     provider: cloudflare
     env:

--- a/clusters/dextek/apps/network/external-dns/ks.yaml
+++ b/clusters/dextek/apps/network/external-dns/ks.yaml
@@ -16,3 +16,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/network/ingress-nginx/external/helmrelease.yaml
+++ b/clusters/dextek/apps/network/ingress-nginx/external/helmrelease.yaml
@@ -16,10 +16,6 @@ spec:
         name: ingress-nginx
         namespace: flux-system
       version: 4.13.2
-  install:
-    crds: Create
-  upgrade:
-    crds: CreateReplace
   values:
     fullnameOverride: nginx-external
     controller:

--- a/clusters/dextek/apps/network/ingress-nginx/internal/helmrelease.yaml
+++ b/clusters/dextek/apps/network/ingress-nginx/internal/helmrelease.yaml
@@ -16,10 +16,6 @@ spec:
         name: ingress-nginx
         namespace: flux-system
       version: 4.13.2
-  install:
-    crds: Create
-  upgrade:
-    crds: CreateReplace
   values:
     fullnameOverride: nginx-internal
     controller:

--- a/clusters/dextek/apps/network/ingress-nginx/ks.yaml
+++ b/clusters/dextek/apps/network/ingress-nginx/ks.yaml
@@ -17,6 +17,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -36,6 +38,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -55,3 +59,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/network/k8s-gateway/app/helmrelease.yaml
+++ b/clusters/dextek/apps/network/k8s-gateway/app/helmrelease.yaml
@@ -15,10 +15,6 @@ spec:
         kind: HelmRepository
         name: k8s-gateway
         namespace: flux-system
-  install:
-    crds: Create
-  upgrade:
-    crds: CreateReplace
   values:
     image:
       registry: ghcr.io

--- a/clusters/dextek/apps/network/k8s-gateway/ks.yaml
+++ b/clusters/dextek/apps/network/k8s-gateway/ks.yaml
@@ -15,3 +15,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/rook-ceph/app/helmrelease.yaml
+++ b/clusters/dextek/apps/rook-ceph/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
       version: v1.18.2
   driftDetection:
     mode: enabled
-  install:
-    crds: CreateReplace
-  upgrade:
-    crds: CreateReplace
   values:
     csi:
       cephFSKernelMountOptions: ms_mode=prefer-crc

--- a/clusters/dextek/apps/rook-ceph/cluster/helmrelease.yaml
+++ b/clusters/dextek/apps/rook-ceph/cluster/helmrelease.yaml
@@ -16,13 +16,6 @@ spec:
         name: rook-release
         namespace: flux-system
   maxHistory: 3
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   uninstall:
     keepHistory: false
   driftDetection:

--- a/clusters/dextek/apps/rook-ceph/ks.yaml
+++ b/clusters/dextek/apps/rook-ceph/ks.yaml
@@ -16,6 +16,8 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -37,3 +39,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/dextek/apps/rook-ceph/ks.yaml
+++ b/clusters/dextek/apps/rook-ceph/ks.yaml
@@ -17,7 +17,7 @@ spec:
   retryInterval: 1m
   timeout: 3m
   components:
-    - ../../../../../shared/components/defaults
+    - ../../../../shared/components/defaults
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -40,4 +40,4 @@ spec:
   retryInterval: 1m
   timeout: 5m
   components:
-    - ../../../../../shared/components/defaults
+    - ../../../../shared/components/defaults

--- a/clusters/dextek/apps/volsync/volsync/app/helmrelease.yaml
+++ b/clusters/dextek/apps/volsync/volsync/app/helmrelease.yaml
@@ -15,14 +15,6 @@ spec:
         kind: HelmRepository
         name: backube
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   # https://github.com/backube/volsync/blob/main/helm/volsync/values.yaml
   values:
     manageCRDs: true

--- a/clusters/dextek/apps/volsync/volsync/ks.yaml
+++ b/clusters/dextek/apps/volsync/volsync/ks.yaml
@@ -18,3 +18,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  components:
+    - ../../../../../shared/components/defaults

--- a/clusters/jotunheim/apps/cert-manager/app/helmrelease.yaml
+++ b/clusters/jotunheim/apps/cert-manager/app/helmrelease.yaml
@@ -15,13 +15,6 @@ spec:
         kind: HelmRepository
         name: jetstack
         namespace: flux-system
-  maxHistory: 3
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     installCRDs: true
     replicaCount: 1

--- a/clusters/jotunheim/apps/default/minio/app/helmrelease.yaml
+++ b/clusters/jotunheim/apps/default/minio/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   values:
     defaultPodOptions:
       securityContext:

--- a/clusters/jotunheim/apps/flux-system/flux-operator/app/helmrelease.yaml
+++ b/clusters/jotunheim/apps/flux-system/flux-operator/app/helmrelease.yaml
@@ -14,14 +14,6 @@ spec:
         kind: HelmRepository
         name: controlplaneio
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   valuesFrom:
     - kind: ConfigMap
       name: flux-operator-helm-values

--- a/clusters/jotunheim/apps/flux-system/flux-operator/instance/helmrelease.yaml
+++ b/clusters/jotunheim/apps/flux-system/flux-operator/instance/helmrelease.yaml
@@ -14,14 +14,6 @@ spec:
         kind: HelmRepository
         name: controlplaneio
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   valuesFrom:
     - kind: ConfigMap
       name: flux-instance-helm-values

--- a/clusters/jotunheim/apps/ingress-nginx/app/helmrelease.yaml
+++ b/clusters/jotunheim/apps/ingress-nginx/app/helmrelease.yaml
@@ -16,10 +16,6 @@ spec:
         name: ingress-nginx
         namespace: flux-system
       version: 4.13.2
-  install:
-    crds: Create
-  upgrade:
-    crds: CreateReplace
   values:
     controller:
       config:

--- a/clusters/jotunheim/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/clusters/jotunheim/apps/kube-system/cilium/app/helmrelease.yaml
@@ -15,12 +15,6 @@ spec:
         kind: HelmRepository
         name: cilium
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: 3
   valuesFrom:
     - kind: ConfigMap
       name: cilium-helm-values

--- a/clusters/jotunheim/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/clusters/jotunheim/apps/kube-system/coredns/app/helmrelease.yaml
@@ -14,14 +14,6 @@ spec:
         kind: HelmRepository
         name: coredns
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   valuesFrom:
     - kind: ConfigMap
       name: coredns-helm-values

--- a/clusters/jotunheim/apps/kube-system/external-secrets/app/helmrelease.yaml
+++ b/clusters/jotunheim/apps/kube-system/external-secrets/app/helmrelease.yaml
@@ -16,13 +16,6 @@ spec:
         name: external-secrets
         namespace: flux-system
   maxHistory: 3
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   uninstall:
     keepHistory: false
   values:

--- a/clusters/jotunheim/apps/kube-system/k8s-gateway/app/helmrelease.yaml
+++ b/clusters/jotunheim/apps/kube-system/k8s-gateway/app/helmrelease.yaml
@@ -15,10 +15,6 @@ spec:
         kind: HelmRepository
         name: k8s-gateway
         namespace: flux-system
-  install:
-    crds: Create
-  upgrade:
-    crds: CreateReplace
   values:
     image:
       registry: ghcr.io

--- a/clusters/jotunheim/apps/kube-system/system-upgrade/app/helmrelease.yaml
+++ b/clusters/jotunheim/apps/kube-system/system-upgrade/app/helmrelease.yaml
@@ -14,14 +14,6 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      strategy: rollback
-      retries: 3
   values:
     controllers:
       system-upgrade:

--- a/clusters/shared/components/defaults/kustomization.yaml
+++ b/clusters/shared/components/defaults/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - target:
+      kind: HelmRelease
+      version: v2
+      group: helm.toolkit.fluxcd.io
+    patch: |-
+      - op: add
+        path: /spec/install
+        value:
+          crds: CreateReplace
+          remediation:
+            retries: -1
+      - op: add
+        path: /spec/upgrade
+        value:
+          cleanupOnFail: true
+          crds: CreateReplace
+          remediation:
+            retries: 3


### PR DESCRIPTION
- Introduced a new component in `clusters/shared/components/defaults/kustomization.yaml` to standardize HelmRelease installation and upgrade settings.
- Updated multiple HelmRelease configurations across various applications to utilize the new shared component defaults, ensuring consistent behavior for CRD handling and remediation strategies.
- Removed redundant installation and upgrade configurations from individual HelmRelease manifests in the `dextek` and `jotunheim` clusters.