### PR TITLE
fix(towonel): change twnl.plexuz.xyz from CNAME to A record

### DIFF
--- a/clusters/dextek/apps/network/towonel-agent/app/dnsendpoint.yaml
+++ b/clusters/dextek/apps/network/towonel-agent/app/dnsendpoint.yaml
@@ -10,9 +10,8 @@ spec:
   endpoints:
     - dnsName: ingress-ext.plexuz.xyz
       recordType: A
-      targets:
+      targets: &ip
         - 62.238.2.224
     - dnsName: twnl.plexuz.xyz
-      recordType: CNAME
-      targets:
-        - ingress-ext.plexuz.xyz
+      recordType: A
+      targets: *ip


### PR DESCRIPTION
Prevents UniFi DNS from following the CNAME chain to ingress-ext.plexuz.xyz and caching/creating an internal IP record for twnl.plexuz.xyz.